### PR TITLE
First run modifier

### DIFF
--- a/docs/demo.twee
+++ b/docs/demo.twee
@@ -490,14 +490,18 @@ in different orders.
 
 :: First Time Insert
 _firstTimeExample: '{first time: "You shield your eyes, but can\'t see who\'s behind the light."}'
+_firstRunExample: "[firstrun]\nIf you close your eyes, it almost feels like you've been here before."
 --
 ## One Of and First Time Inserts: Showing Text the First Time
 
 The `{firstTimeInsert}` insert only shows
-its text the first time the player visits the passage. Consider the code:
+its text the first time the player visits the passage. The `{firstRunMod}` modifier does the same,
+but as a modifier. Consider the code:
 
 <pre>
 The floodlight illuminating you is painfully bright. {_firstTimeExample}
+
+{_firstRunExample}
 </pre>
 
 The first time the player visits the passage, they'll see:
@@ -505,6 +509,8 @@ The first time the player visits the passage, they'll see:
 <blockquote>
 The floodlight illuminating you is painfully bright. You shield your eyes, but can't 
 see who's behind the light.
+
+If you close your eyes, it almost feels like you've been here before.
 </blockquote>
 
 The second time, and every time after that, the player will see:
@@ -522,6 +528,7 @@ The floodlight illuminating you is painfully bright.
 
 :: First Time Demo
 _firstTimeInsertDemo: "{first time: 'You catch your foot on a stalagmite and nearly fall.'}"
+_firstRunModifierDemo: "[firstrun]\nYou have no memory of this place."
 --
 ## Showing First Time in Action
 
@@ -529,12 +536,19 @@ This passage contains the code:
 
 <pre>
 The cave is low and dark. {_firstTimeInsertDemo}
+
+{_firstRunModifierDemo}
 </pre>
 
 Here's what it looks like.
 
 <blockquote>
 The cave is low and dark. {first time: 'You catch your foot on a stalagmite and nearly fall.'}
+
+[firstrun]
+You have no memory of this place.
+
+[cont]
 </blockquote>
 
 > [[View this passage again->First Time Demo]]

--- a/docs/demo.twee
+++ b/docs/demo.twee
@@ -490,7 +490,7 @@ in different orders.
 
 :: First Time Insert
 _firstTimeExample: '{first time: "You shield your eyes, but can\'t see who\'s behind the light."}'
-_firstRunExample: "[firstrun]\nIf you close your eyes, it almost feels like you've been here before."
+_firstRunExample: "[first time]\nIf you close your eyes, it almost feels like you've been here before."
 --
 ## One Of and First Time Inserts: Showing Text the First Time
 
@@ -528,7 +528,7 @@ The floodlight illuminating you is painfully bright.
 
 :: First Time Demo
 _firstTimeInsertDemo: "{first time: 'You catch your foot on a stalagmite and nearly fall.'}"
-_firstRunModifierDemo: "[firstrun]\nYou have no memory of this place."
+_firstRunModifierDemo: "[first time]\nYou have no memory of this place."
 --
 ## Showing First Time in Action
 
@@ -545,7 +545,7 @@ Here's what it looks like.
 <blockquote>
 The cave is low and dark. {first time: 'You catch your foot on a stalagmite and nearly fall.'}
 
-[firstrun]
+[first time]
 You have no memory of this place.
 
 [cont]

--- a/src/text-manipulation.twee
+++ b/src/text-manipulation.twee
@@ -142,6 +142,21 @@ engine.extend('2.0.0', () => {
             }
         }
     });
+
+    engine.template.modifiers.add({
+        name: "firstrun",
+        description: "Show modified text only the first time the passage is viewed.",
+        match: /^firstrun\b/i,
+        process(output, {invocation, state}) {
+            const hash = libfunc.hashInvocation(invocation);
+            if (zOneOfTracking[hash] === undefined) {
+                zOneOfTracking[hash] = true;
+            } else {
+                output.text = '';
+                output.startsNewParagraph = false;
+            }
+        }
+    });
 });
 
 [Javascript]

--- a/src/text-manipulation.twee
+++ b/src/text-manipulation.twee
@@ -144,9 +144,9 @@ engine.extend('2.0.0', () => {
     });
 
     engine.template.modifiers.add({
-        name: "firstrun",
+        name: "first time",
         description: "Show modified text only the first time the passage is viewed.",
-        match: /^firstrun\b/i,
+        match: /^first\s+time\b/i,
         process(output, {invocation, state}) {
             const hash = libfunc.hashInvocation(invocation);
             if (zOneOfTracking[hash] === undefined) {


### PR DESCRIPTION
Add a `[firstrun]` modifier that performs the same function as the `{first time: 'abc'}` inserter. This allows better handling of paragraphs and formatted text, including conditionally importing other passages.

Edits and feedback are welcome. Potentially using this in a project and wanted to share the code.